### PR TITLE
add runtime check for name availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Check name availability in runtime (DEV only)
 
 ## [0.12.0] - 2019-06-07
 ### Changed

--- a/dist/index.js
+++ b/dist/index.js
@@ -92,7 +92,17 @@ var createGlobalStateCommon = function createGlobalStateCommon(initialState) {
     }, children);
   };
 
+  var validateName = function validateName(name) {
+    if (!keys.includes(name)) {
+      throw new Error("Name not Found: '".concat(name, "'. It must be provided in initialState as a property key."));
+    }
+  };
+
   var setGlobalState = function setGlobalState(name, update) {
+    if (process.env.NODE_ENV !== 'production') {
+      validateName(name);
+    }
+
     wholeGlobalState = _objectSpread({}, wholeGlobalState, _defineProperty({}, name, updateValue(wholeGlobalState[name], update)));
 
     if (listener) {
@@ -101,6 +111,10 @@ var createGlobalStateCommon = function createGlobalStateCommon(initialState) {
   };
 
   var useGlobalState = function useGlobalState(name) {
+    if (process.env.NODE_ENV !== 'production') {
+      validateName(name);
+    }
+
     var index = keys.indexOf(name);
     var observedBits = 1 << index;
     var state = useUnstableContextWithoutWarning(Context, observedBits);
@@ -111,6 +125,10 @@ var createGlobalStateCommon = function createGlobalStateCommon(initialState) {
   };
 
   var getGlobalState = function getGlobalState(name) {
+    if (process.env.NODE_ENV !== 'production') {
+      validateName(name);
+    }
+
     var ReactCurrentDispatcher = _react.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentDispatcher;
     var dispatcher = ReactCurrentDispatcher.current;
 

--- a/examples/01_minimal/src/index.js
+++ b/examples/01_minimal/src/index.js
@@ -10,7 +10,7 @@ const initialState = {
 const { GlobalStateProvider, useGlobalState } = createGlobalState(initialState);
 
 const Counter = () => {
-  const [value, update] = useGlobalState('counter2');
+  const [value, update] = useGlobalState('counter');
   return (
     <div>
       <span>Count:{value}</span>

--- a/examples/01_minimal/src/index.js
+++ b/examples/01_minimal/src/index.js
@@ -10,7 +10,7 @@ const initialState = {
 const { GlobalStateProvider, useGlobalState } = createGlobalState(initialState);
 
 const Counter = () => {
-  const [value, update] = useGlobalState('counter');
+  const [value, update] = useGlobalState('counter2');
   return (
     <div>
       <span>Count:{value}</span>

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,16 @@ const createGlobalStateCommon = (initialState) => {
     return createElement(Context.Provider, { value: state }, children);
   };
 
+  const validateName = (name) => {
+    if (!keys.includes(name)) {
+      throw new Error(`Name not Found: '${name}'. It must be provided in initialState as a property key.`);
+    }
+  };
+
   const setGlobalState = (name, update) => {
+    if (process.env.NODE_ENV !== 'production') {
+      validateName(name);
+    }
     wholeGlobalState = {
       ...wholeGlobalState,
       [name]: updateValue(wholeGlobalState[name], update),
@@ -77,6 +86,9 @@ const createGlobalStateCommon = (initialState) => {
   };
 
   const useGlobalState = (name) => {
+    if (process.env.NODE_ENV !== 'production') {
+      validateName(name);
+    }
     const index = keys.indexOf(name);
     const observedBits = 1 << index;
     const state = useUnstableContextWithoutWarning(Context, observedBits);
@@ -85,6 +97,9 @@ const createGlobalStateCommon = (initialState) => {
   };
 
   const getGlobalState = (name) => {
+    if (process.env.NODE_ENV !== 'production') {
+      validateName(name);
+    }
     const { ReactCurrentDispatcher } = __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
     const dispatcher = ReactCurrentDispatcher.current;
     if (dispatcher) {


### PR DESCRIPTION
Thanks to @vans163 again, this will show a runtime error if a name is not provided in initialState. It checks only in non-production env.
Closes #19.
