### PR TITLE
add browser to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",
+  "browser": "./dist/index.js",
   "types": "./src/index.d.ts",
   "files": [
     "src",


### PR DESCRIPTION
Compatibility issue using webpack with Microsoft Edge. Webpack prioritizes the module field over main in package.json. Module points to src while main points to dist. This creates some issues as index.js in src uses the spread operator which is not entirely supported on Edge. Issue [here](https://github.com/webpack/webpack/issues/5756) details the problem and offers a solution by adding the browser field into package.json. 