### PR TITLE
expose "subscribe" function for "createGlobalState"

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ It returns a set of functions
 *   `useGlobalState`: a custom hook works like React.useState
 *   `getGlobalState`: a function to get a global state by key outside React
 *   `setGlobalState`: a function to set a global state by key outside React
+*   `subscribe`: a function that subscribes to state changes
 
 #### Parameters
 

--- a/__tests__/01_basic_spec.tsx
+++ b/__tests__/01_basic_spec.tsx
@@ -72,8 +72,8 @@ describe('basic spec', () => {
     const { useGlobalState, subscribe } = createGlobalState({
       count: 0,
     });
-    subscribe((state) => {
-      containerRef.current?.setAttribute('data-testid', `count ${state.count}`);
+    subscribe('count', (count) => {
+      containerRef.current?.setAttribute('data-testid', `count ${count}`);
     });
 
     const Counter = () => {

--- a/__tests__/01_basic_spec.tsx
+++ b/__tests__/01_basic_spec.tsx
@@ -64,4 +64,40 @@ describe('basic spec', () => {
     fireEvent.click(getAllByText('+1')[0] as HTMLElement);
     expect(container).toMatchSnapshot();
   });
+
+  it('should subscribe to global state change', () => {
+    const containerRef : { current: null | HTMLDivElement } = {
+      current: null,
+    };
+    const { useGlobalState, subscribe } = createGlobalState({
+      count: 0,
+    });
+    subscribe((state) => {
+      containerRef.current?.setAttribute('data-testid', `count ${state.count}`);
+    });
+
+    const Counter = () => {
+      const [value, update] = useGlobalState('count');
+      return (
+        <div
+          ref={(ref) => {
+            if (ref) {
+              containerRef.current = ref;
+            }
+          }}
+        >
+          <span>{value}</span>
+          <button type="button" onClick={() => update(value + 1)}>+1</button>
+        </div>
+      );
+    };
+    const App = () => (
+      <StrictMode>
+        <Counter />
+      </StrictMode>
+    );
+    const { getByTestId, getAllByText } = render(<App />);
+    fireEvent.click(getAllByText('+1')[0] as HTMLElement);
+    expect(getByTestId('count 1')).toBeDefined();
+  });
 });

--- a/src/createGlobalState.ts
+++ b/src/createGlobalState.ts
@@ -70,10 +70,21 @@ export const createGlobalState = <State extends object>(initialState: State) => 
     return useStore.getState()[stateKey];
   };
 
+  const subscribe = <StateKey extends StateKeys>(
+    stateKey: StateKey,
+    listener: (value: State[StateKey]) => void,
+  ) => {
+    useStore.subscribe((state, prevState) => {
+      if (state[stateKey] !== prevState[stateKey]) {
+        listener(state[stateKey]);
+      }
+    });
+  };
+
   return {
     useGlobalState,
     getGlobalState,
     setGlobalState,
-    subscribe: useStore.subscribe,
+    subscribe,
   };
 };

--- a/src/createGlobalState.ts
+++ b/src/createGlobalState.ts
@@ -74,5 +74,6 @@ export const createGlobalState = <State extends object>(initialState: State) => 
     useGlobalState,
     getGlobalState,
     setGlobalState,
+    subscribe: useStore.subscribe,
   };
 };

--- a/src/createGlobalState.ts
+++ b/src/createGlobalState.ts
@@ -21,6 +21,7 @@ const updateValue = <Value>(oldValue: Value, newValue: SetStateAction<Value>) =>
  * - `useGlobalState`: a custom hook works like React.useState
  * - `getGlobalState`: a function to get a global state by key outside React
  * - `setGlobalState`: a function to set a global state by key outside React
+ * - `subscribe`: a function that subscribes to state changes
  *
  * @example
  * import { createGlobalState } from 'react-hooks-global-state';


### PR DESCRIPTION
The `subscribe` function would be very helpful, because I often need to persist some parts of global state in local storage, and there is no easy and clean way to do this. Best I could do is to create an effects-only component that listens global state by hooks, which works but is verbose and feels complicated.